### PR TITLE
Fix trait objects without explicit `dyn`.

### DIFF
--- a/rust/cmsis-update/src/download.rs
+++ b/rust/cmsis-update/src/download.rs
@@ -150,7 +150,7 @@ where
         &'a self,
         source: Url,
         dest: PathBuf,
-    ) -> Box<Future<Item = (), Error = Error> + 'a> {
+    ) -> Box<dyn Future<Item = (), Error = Error> + 'a> {
         if !dest.exists() {
             dest.parent().map(create_dir_all);
             Box::new(
@@ -185,7 +185,7 @@ where
     pub fn download_stream<F, DL>(
         &'a self,
         stream: F,
-    ) -> Box<Stream<Item = PathBuf, Error = Error> + 'a>
+    ) -> Box<dyn Stream<Item = PathBuf, Error = Error> + 'a>
     where
         F: Stream<Item = DL, Error = Error> + 'a,
         DL: IntoDownload + 'a,

--- a/rust/pdsc/src/component.rs
+++ b/rust/pdsc/src/component.rs
@@ -222,7 +222,7 @@ impl FromElem for Bundle {
 fn child_to_component_iter(
     e: &Element,
     l: &Logger,
-) -> Result<Box<Iterator<Item = ComponentBuilder>>, Error> {
+) -> Result<Box<dyn Iterator<Item = ComponentBuilder>>, Error> {
     match e.name() {
         "bundle" => {
             let bundle = Bundle::from_elem(e, l)?;


### PR DESCRIPTION
We have come rust compiler warnings:

```
warning: trait objects without an explicit `dyn` are deprecated
   --> pdsc/src/component.rs:225:17
    |
225 | ) -> Result<Box<Iterator<Item = ComponentBuilder>>, Error> {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Iterator<Item = ComponentBuilder>`
    |
    = note: `#[warn(bare_trait_objects)]` on by default

   Compiling reqwest v0.9.22
   Compiling cmsis-update v0.1.0 (/home/jankii01/mbed/cmsis-pack-manager/rust/cmsis-update)
warning: trait objects without an explicit `dyn` are deprecated
   --> cmsis-update/src/download.rs:153:14
    |
153 |     ) -> Box<Future<Item = (), Error = Error> + 'a> {
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Future<Item = (), Error = Error> + 'a`
    |
    = note: `#[warn(bare_trait_objects)]` on by default

warning: trait objects without an explicit `dyn` are deprecated
   --> cmsis-update/src/download.rs:188:14
    |
188 |     ) -> Box<Stream<Item = PathBuf, Error = Error> + 'a>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Stream<Item = PathBuf, Error = Error> + 'a`
```

The compiler is pretty cool, as the warning it gives already tells you
the real fix, too.

This fixes issue; https://github.com/ARMmbed/cmsis-pack-manager/issues/125
